### PR TITLE
Remove stuff categories from unfinished prosthetics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 1.3.0
 
 - Module slots are now contained by Crafted Mutants (#6)
+- Upgrading prosthetics doesn't throw an error anymore (#9)
 
 ## Version 1.2.1
 

--- a/Defs/ThingDefs_Items/Items_UnfinishedProsthesis.xml
+++ b/Defs/ThingDefs_Items/Items_UnfinishedProsthesis.xml
@@ -32,9 +32,6 @@
 			<li>Unfinished</li>
 		</thingCategories>
 		<stuffCategories>
-			<li>Metallic</li>
-			<li>Woody</li>
-			<li>Stony</li>
 		</stuffCategories>
 	</ThingDef>
 


### PR DESCRIPTION
This should fix it, I think the code was just old and the way it is defined overwrites the EPOE version

Fixes #9 